### PR TITLE
fix: Work around inability to override a certificate's serial number

### DIFF
--- a/src/app/background_queue/processor.ts
+++ b/src/app/background_queue/processor.ts
@@ -97,6 +97,14 @@ export class PingProcessor {
         ? await parcelPayload.getOriginatorKey()
         : undefined;
 
+    // TODO: REMOVE
+    const recipientKeyId = parcelPayload.getRecipientKeyId();
+    // tslint:disable-next-line:no-console
+    console.log('BADGER', {
+      envelopedDataType: typeof parcelPayload,
+      recipientKeyId: recipientKeyId.toString('base64'),
+    });
+
     const message = await pingParcel.unwrapPayload(this.privateKeyStore);
     return { message, originatorKey };
   }

--- a/src/app/background_queue/processor.ts
+++ b/src/app/background_queue/processor.ts
@@ -101,7 +101,7 @@ export class PingProcessor {
     const recipientKeyId = parcelPayload.getRecipientKeyId();
     // tslint:disable-next-line:no-console
     console.log('BADGER', {
-      envelopedDataType: typeof parcelPayload,
+      envelopedDataType: parcelPayload.constructor.name,
       recipientKeyId: recipientKeyId.toString('base64'),
     });
 

--- a/src/app/background_queue/processor.ts
+++ b/src/app/background_queue/processor.ts
@@ -9,7 +9,7 @@ import {
   SessionOriginatorKey,
 } from '@relaycorp/relaynet-core';
 import { deliverParcel } from '@relaycorp/relaynet-pohttp';
-import bufferToArray = require('buffer-to-arraybuffer');
+import bufferToArray from 'buffer-to-arraybuffer';
 import { Job } from 'bull';
 import pino = require('pino');
 

--- a/src/app/background_queue/processor.ts
+++ b/src/app/background_queue/processor.ts
@@ -97,14 +97,6 @@ export class PingProcessor {
         ? await parcelPayload.getOriginatorKey()
         : undefined;
 
-    // TODO: REMOVE
-    const recipientKeyId = parcelPayload.getRecipientKeyId();
-    // tslint:disable-next-line:no-console
-    console.log('BADGER', {
-      envelopedDataType: parcelPayload.constructor.name,
-      recipientKeyId: recipientKeyId.toString('base64'),
-    });
-
     const message = await pingParcel.unwrapPayload(this.privateKeyStore);
     return { message, originatorKey };
   }

--- a/src/app/pingSerialization.ts
+++ b/src/app/pingSerialization.ts
@@ -1,6 +1,6 @@
 import { Certificate, RelaynetError } from '@relaycorp/relaynet-core';
 import { Parser } from 'binary-parser';
-import bufferToArray = require('buffer-to-arraybuffer');
+import bufferToArray from 'buffer-to-arraybuffer';
 import uuid4 from 'uuid4';
 
 const pingParser = new Parser()

--- a/src/functional_tests/main.test.ts
+++ b/src/functional_tests/main.test.ts
@@ -60,11 +60,6 @@ describe('End-to-end test for successful delivery of ping and pong messages', ()
     const pongEndpointKeyId = Buffer.from(PONG_ENDPOINT_KEY_ID_BASE64, 'base64');
     await privateKeyStore.saveNodeKey(pongEndpointPrivateKey, pongEndpointKeyId);
 
-    // TODO: REMOVE
-    const savedKey = await privateKeyStore.fetchNodeKey(pongEndpointKeyId);
-    // tslint:disable-next-line:no-console
-    console.log('BADGER', { savedKey: savedKey.constructor.name, PONG_ENDPOINT_KEY_ID_BASE64 });
-
     pongEndpointCertificate = await issueEndpointCertificate({
       issuerPrivateKey: pongEndpointPrivateKey,
       subjectPublicKey: pongEndpointKeyPair.publicKey,

--- a/src/functional_tests/main.test.ts
+++ b/src/functional_tests/main.test.ts
@@ -63,7 +63,7 @@ describe('End-to-end test for successful delivery of ping and pong messages', ()
     // TODO: REMOVE
     const savedKey = await privateKeyStore.fetchNodeKey(pongEndpointKeyId);
     // tslint:disable-next-line:no-console
-    console.log('BADGER', { savedKey: savedKey.constructor.name, PONG_ENDPOINT_KEY_ID_BASE64});
+    console.log('BADGER', { savedKey: savedKey.constructor.name, PONG_ENDPOINT_KEY_ID_BASE64 });
 
     pongEndpointCertificate = await issueEndpointCertificate({
       issuerPrivateKey: pongEndpointPrivateKey,

--- a/src/functional_tests/main.test.ts
+++ b/src/functional_tests/main.test.ts
@@ -57,10 +57,13 @@ describe('End-to-end test for successful delivery of ping and pong messages', ()
     const pongEndpointKeyPair = await generateRSAKeyPair();
     pongEndpointPrivateKey = pongEndpointKeyPair.privateKey;
 
-    await privateKeyStore.saveNodeKey(
-      pongEndpointPrivateKey,
-      Buffer.from(PONG_ENDPOINT_KEY_ID_BASE64, 'base64'),
-    );
+    const pongEndpointKeyId = Buffer.from(PONG_ENDPOINT_KEY_ID_BASE64, 'base64');
+    await privateKeyStore.saveNodeKey(pongEndpointPrivateKey, pongEndpointKeyId);
+
+    // TODO: REMOVE
+    const savedKey = await privateKeyStore.fetchNodeKey(pongEndpointKeyId);
+    // tslint:disable-next-line:no-console
+    console.log('BADGER', { savedKey: typeof savedKey, PONG_ENDPOINT_KEY_ID_BASE64});
 
     pongEndpointCertificate = await issueEndpointCertificate({
       issuerPrivateKey: pongEndpointPrivateKey,

--- a/src/functional_tests/main.test.ts
+++ b/src/functional_tests/main.test.ts
@@ -70,6 +70,12 @@ describe('End-to-end test for successful delivery of ping and pong messages', ()
       subjectPublicKey: pongEndpointKeyPair.publicKey,
       validityEndDate: TOMORROW,
     });
+    // Force the certificate to have the serial number specified in ENDPOINT_KEY_ID. This nasty
+    // hack won't be necessary once https://github.com/relaycorp/relaynet-pong/issues/26 is done.
+    // tslint:disable-next-line:no-object-mutation
+    pongEndpointCertificate.pkijsCertificate.serialNumber.valueBlock.valueHex = bufferToArray(
+      pongEndpointKeyId,
+    );
 
     const pingSenderKeyPair = await generateRSAKeyPair();
     pingSenderPrivateKey = pingSenderKeyPair.privateKey;

--- a/src/functional_tests/main.test.ts
+++ b/src/functional_tests/main.test.ts
@@ -63,7 +63,7 @@ describe('End-to-end test for successful delivery of ping and pong messages', ()
     // TODO: REMOVE
     const savedKey = await privateKeyStore.fetchNodeKey(pongEndpointKeyId);
     // tslint:disable-next-line:no-console
-    console.log('BADGER', { savedKey: typeof savedKey, PONG_ENDPOINT_KEY_ID_BASE64});
+    console.log('BADGER', { savedKey: savedKey.constructor.name, PONG_ENDPOINT_KEY_ID_BASE64});
 
     pongEndpointCertificate = await issueEndpointCertificate({
       issuerPrivateKey: pongEndpointPrivateKey,

--- a/src/types/buffer-to-arraybuffer.d.ts
+++ b/src/types/buffer-to-arraybuffer.d.ts
@@ -1,4 +1,4 @@
 declare module 'buffer-to-arraybuffer' {
   function bufferToArray(buffer: Buffer): ArrayBuffer;
-  export = bufferToArray;
+  export default bufferToArray;
 }


### PR DESCRIPTION
This is a workaround until #26 has been implemented.