### PR TITLE
fix: Include ping parcel certificate chain in pong sender chain

### DIFF
--- a/src/app/background_queue/processor.ts
+++ b/src/app/background_queue/processor.ts
@@ -47,6 +47,12 @@ export class PingProcessor {
       pingParcel.senderCertificate.getCommonName(),
       ping.pda,
       pongParcelPayload,
+      {
+        senderCaCertificateChain: [
+          pingParcel.senderCertificate,
+          ...pingParcel.senderCaCertificateChain,
+        ],
+      },
     );
     const parcelSerialized = await pongParcel.serialize(keyPair.privateKey);
     try {


### PR DESCRIPTION
Otherwise, public gateways won't be able to verify the PDA in pong messages.