### PR TITLE
fix(chart): Avoid clash with Kubernetes job to configure Vault

### DIFF
--- a/chart/templates/vault-config-job.yml
+++ b/chart/templates/vault-config-job.yml
@@ -12,7 +12,7 @@ metadata:
 spec:
   template:
     metadata:
-      name: "{{ .Release.Name }}-vault-config"
+      name: "{{ .Release.Name }}-vault-config-pong"
       labels:
         app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
         app.kubernetes.io/instance: {{ .Release.Name | quote }}


### PR DESCRIPTION
The Relaynet-Internet Gateway has the same job name, so it doesn't work when deploying the two locally.